### PR TITLE
eval: strengthen benchmark protocol and reporting

### DIFF
--- a/docs/evaluation-protocol.md
+++ b/docs/evaluation-protocol.md
@@ -1,0 +1,90 @@
+# Evaluation Protocol
+
+This document defines the recommended duplicate-evaluation workflow and the fields expected in generated reports.
+
+## Goal
+
+Keep model comparisons decision-ready and comparable across runs.
+
+## Core Rules
+
+- compare runs under the same `rule_profile_id`
+- compare runs under the same `spec_version`
+- compare runs under the same `seed_set_id`
+- compare runs under the same `opponent_suite_id`
+- avoid mixing exploratory dev reports with milestone-level test reports
+
+## Recommended Flow
+
+### 1) Generate a model duplicate report
+
+```powershell
+uv run python rl/eval_duplicate.py ^
+  --model models/ppo_main ^
+  --seed_set test ^
+  --strict_load ^
+  --fail_on_fallback ^
+  --out reports/dup_main_seedset_test.json
+```
+
+### 2) Generate the rule baseline report
+
+```powershell
+uv run python rl/eval_duplicate.py ^
+  --model models/unused ^
+  --policy_mode rule ^
+  --seed_set test ^
+  --out reports/dup_rule_seedset_test.json
+```
+
+### 3) Build a comparison trend report
+
+```powershell
+uv run python rl/build_duplicate_trend.py ^
+  --reports reports/dup_main_seedset_test.json reports/dup_rule_seedset_test.json ^
+  --out_md reports/duplicate_trend.md ^
+  --out_json reports/duplicate_trend.json
+```
+
+## Required Fields In Duplicate Reports
+
+The duplicate evaluation report should include:
+
+- `report_schema_version`
+- `mean_diff`
+- `std_diff`
+- `ci95`
+- `n_games`
+- `rule_profile_id`
+- `spec_version`
+- `seed_set_id`
+- `opponent_suite_id`
+
+## Required Fields In Trend Reports
+
+The trend JSON should include:
+
+- `report_schema_version`
+- `rows`
+
+Each row should preserve:
+
+- version name derived from the report path
+- policy/backend summary
+- duplicate metrics
+- comparison context (`rule_profile_id`, `spec_version`, `seed_set_id`, `opponent_suite_id`)
+
+## Comparison Example
+
+Interpretation example:
+
+- use `mean_diff` as the headline value
+- use `lower_ci95` to check whether advantage remains positive under uncertainty
+- reject comparisons when context fields do not match
+
+## Recommendation
+
+- use `seed_set=dev` for tuning
+- use `seed_set=test` for milestone statements
+- keep the JSON report outputs under version control only when they are intentionally curated artifacts
+

--- a/rl/build_duplicate_trend.py
+++ b/rl/build_duplicate_trend.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from typing import Dict, List
 
+REPORT_SCHEMA_VERSION = "duplicate_trend.v1"
+
 
 def _load_report(path: Path) -> Dict:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -34,6 +36,10 @@ def build_trend(reports: List[Path], out_md: Path, out_json: Path | None = None)
                 "std_diff": float(report.get("std_diff", 0.0)),
                 "ci95": ci95,
                 "lower_ci95": mean - ci95,
+                "rule_profile_id": str(report.get("rule_profile_id", "")),
+                "spec_version": str(report.get("spec_version", "")),
+                "seed_set_id": str(report.get("seed_set_id", "")),
+                "opponent_suite_id": str(report.get("opponent_suite_id", "")),
             }
         )
 
@@ -42,17 +48,31 @@ def build_trend(reports: List[Path], out_md: Path, out_json: Path | None = None)
     out_md.parent.mkdir(parents=True, exist_ok=True)
     with out_md.open("w", encoding="utf-8") as f:
         f.write("# Duplicate Trend\n\n")
-        f.write("| Version | Policy | Backend | Games | Mean Diff | CI95 | Lower CI95 | Report |\n")
-        f.write("|---|---|---:|---:|---:|---:|---:|---|\n")
+        f.write(
+            "| Version | Policy | Backend | Games | Mean Diff | CI95 | Lower CI95 | Rule Profile | Spec | Seed Set | Opponent Suite | Report |\n"
+        )
+        f.write("|---|---|---:|---:|---:|---:|---:|---|---|---|---|---|\n")
         for row in rows:
             f.write(
                 f"| {row['version']} | {row['policy_mode']} | {row['backend']} | {row['n_games']} | "
-                f"{row['mean_diff']:.4f} | {row['ci95']:.4f} | {row['lower_ci95']:.4f} | `{row['report']}` |\n"
+                f"{row['mean_diff']:.4f} | {row['ci95']:.4f} | {row['lower_ci95']:.4f} | "
+                f"{row['rule_profile_id']} | {row['spec_version']} | {row['seed_set_id']} | "
+                f"{row['opponent_suite_id']} | `{row['report']}` |\n"
             )
 
     if out_json is not None:
         out_json.parent.mkdir(parents=True, exist_ok=True)
-        out_json.write_text(json.dumps({"rows": rows}, ensure_ascii=True, indent=2), encoding="utf-8")
+        out_json.write_text(
+            json.dumps(
+                {
+                    "report_schema_version": REPORT_SCHEMA_VERSION,
+                    "rows": rows,
+                },
+                ensure_ascii=True,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
 
     print(f"saved_md={out_md} rows={len(rows)}")
     if out_json is not None:
@@ -70,4 +90,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/rl/eval_duplicate.py
+++ b/rl/eval_duplicate.py
@@ -18,6 +18,8 @@ from env import HangzhouMahjongEnv
 from rl.report_context import build_report_context, read_spec_version
 from rl.seed_splits import DEFAULT_SEED_SPLITS, classify_seed_set, resolve_seed_set
 
+REPORT_SCHEMA_VERSION = "duplicate_eval.v1"
+
 
 class PolicyRunner:
     def __init__(self, model_path: str, strict_load: bool = False):
@@ -285,6 +287,7 @@ def evaluate(
     )
 
     report = {
+        "report_schema_version": REPORT_SCHEMA_VERSION,
         "model": model,
         "resolved_model_path": policy.resolved_model_path,
         "backend": policy.backend,

--- a/tests/test_build_duplicate_trend.py
+++ b/tests/test_build_duplicate_trend.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+from rl.build_duplicate_trend import REPORT_SCHEMA_VERSION, build_trend
+
+
+def _write_report(path: Path, *, mean_diff: float, policy_mode: str) -> None:
+    payload = {
+        "report_schema_version": "duplicate_eval.v1",
+        "policy_mode": policy_mode,
+        "backend": "sb3",
+        "n_games": 200,
+        "mean_diff": mean_diff,
+        "std_diff": 3.0,
+        "ci95": 0.5,
+        "rule_profile_id": "hz_local_v2026_02_A",
+        "spec_version": "v1.1",
+        "seed_set_id": "test",
+        "opponent_suite_id": "mix=rule:1.0|eps=0.080",
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
+def test_build_trend_writes_schema_and_context_fields(tmp_path: Path):
+    report_a = tmp_path / "dup_model_a.json"
+    report_b = tmp_path / "dup_model_b.json"
+    out_md = tmp_path / "duplicate_trend.md"
+    out_json = tmp_path / "duplicate_trend.json"
+
+    _write_report(report_a, mean_diff=10.0, policy_mode="model")
+    _write_report(report_b, mean_diff=8.0, policy_mode="rule")
+
+    build_trend([report_a, report_b], out_md=out_md, out_json=out_json)
+
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["report_schema_version"] == REPORT_SCHEMA_VERSION
+    assert len(payload["rows"]) == 2
+    assert payload["rows"][0]["rule_profile_id"] == "hz_local_v2026_02_A"
+    assert payload["rows"][0]["spec_version"] == "v1.1"
+    assert payload["rows"][0]["seed_set_id"] == "test"
+    assert payload["rows"][0]["opponent_suite_id"] == "mix=rule:1.0|eps=0.080"
+
+    markdown = out_md.read_text(encoding="utf-8")
+    assert "Rule Profile" in markdown
+    assert "Opponent Suite" in markdown
+

--- a/tests/test_eval_duplicate_strict.py
+++ b/tests/test_eval_duplicate_strict.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from rl.eval_duplicate import PolicyRunner, build_policy_runner, evaluate, resolve_seed_list
+from rl.eval_duplicate import REPORT_SCHEMA_VERSION, PolicyRunner, build_policy_runner, evaluate, resolve_seed_list
 
 
 def test_policy_runner_fallback_when_model_missing():
@@ -97,6 +97,7 @@ def test_evaluate_report_includes_opponent_epsilon(tmp_path: Path):
         opponent_epsilon=0.23,
     )
     report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["report_schema_version"] == REPORT_SCHEMA_VERSION
     assert report["opponent_epsilon"] == pytest.approx(0.23)
     assert report["opponent_mix"] == "rule:1.0"
     assert report["seed_set_id"] != ""


### PR DESCRIPTION
## Summary
Strengthen duplicate evaluation reporting with schema versioning, clearer comparison context, and a dedicated protocol document.

## What changed
- Added `report_schema_version` to duplicate evaluation reports
- Added `report_schema_version` to duplicate trend JSON output
- Expanded trend rows with context fields used for fair comparisons
- Added `docs/evaluation-protocol.md`
- Added test coverage for trend report generation and duplicate report schema

## Validation
- `uv run pytest tests/test_eval_duplicate_strict.py tests/test_build_duplicate_trend.py tests/test_assess_model_readiness.py -q`

Closes #5